### PR TITLE
Fix

### DIFF
--- a/lib/src/config/util.dart
+++ b/lib/src/config/util.dart
@@ -84,8 +84,8 @@ extension FontSize on ResizableText {
   ]) {
     final _style = style ??
         ButtonStyle(
-          elevation: const MaterialStatePropertyAll(4),
-          padding: MaterialStatePropertyAll(
+          elevation: MaterialStateProperty.all(4),
+          padding: MaterialStateProperty.all(
             EdgeInsets.symmetric(
               horizontal: 2.5 * (Get.width / 200),
               vertical: Get.width / 200,
@@ -103,13 +103,13 @@ extension FontSize on ResizableText {
   TextButton toTextButton(VoidFunction onPressed, [ButtonStyle? style]) {
     final _style = style ??
         ButtonStyle(
-          textStyle: const MaterialStatePropertyAll(
-            TextStyle(
+          textStyle: MaterialStateProperty.all(
+            const TextStyle(
               decoration: TextDecoration.underline,
               fontStyle: FontStyle.italic,
             ),
           ),
-          padding: MaterialStatePropertyAll(
+          padding: MaterialStateProperty.all(
             EdgeInsets.symmetric(
               horizontal: 2.5 * (Get.width / 200),
               vertical: Get.width / 200,


### PR DESCRIPTION
I have fixed it so that the old configuration is not reused on a new log in. Previously the old configuration with the old (now logged out) user was reused when opening the new realm.

I have also done some changes to how you await subscription synchronisation and download/upload so that the timeout pertains to all 3 operations.

I would probably recommend not awaiting these at all, and just let them complete in the background. In particular I think it is a bit heavy handed to log out the user, just because the sync times out.